### PR TITLE
added check for linux

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,10 @@
+use std::env;
+
 mod app;
 
 fn main() {
+    if env::consts::OS != "linux" {
+        panic!("We don't support {} yet!", env::consts::OS);
+    }
     app::mainloop();
 }


### PR DESCRIPTION
Fixes issue #8
This doesn't use the os_info crate, as it doesn't support OS families.